### PR TITLE
 Grid Tarjetas SIM en Lin Moviles

### DIFF
--- a/app/models/lin_movil.rb
+++ b/app/models/lin_movil.rb
@@ -12,6 +12,7 @@ class LinMovil < ApplicationRecord
     has_one :perfiles_movil, :foreign_key => "cPerfil", :primary_key => "cPerfil"    
     has_one :sede, :foreign_key => "nCodSede", :primary_key => "nCodSede"
     has_many :terminal_movil, :foreign_key => "nLinea", :primary_key => "nLinea"    
+    has_many :tarjeta_movil, :foreign_key => "nLineaMovil", :primary_key => "nLinea"    
 
     ransack_alias :lin_movil, :linea_cNumero_or_linea_cNumCorto_or_cObserva_or_cPerfil_or_cPerfilAutorizado_or_cCoberturaNormativa_or_cDNI_or_persona_cnombre_or_persona_cape1_or_persona_cape2_or_linea_unidad_cDenominacion_or_tipo_lin_movil_cDescTipoMovil_or_sede_cNombre
     

--- a/app/models/tarjeta_movil.rb
+++ b/app/models/tarjeta_movil.rb
@@ -1,0 +1,8 @@
+class TarjetaMovil < ApplicationRecord
+
+    self.table_name ="geslico.dbo.TTarjetasMovil"
+    self.primary_key="cICC"
+
+    belongs_to :linea, :foreign_key => "nLineaMovil", :primary_key => "nLinea"
+
+end

--- a/app/views/lin_moviles/_form.html.erb
+++ b/app/views/lin_moviles/_form.html.erb
@@ -87,6 +87,7 @@
         <%= render 'linea', f: f %>      
         <%= render 'persona', persona: @lin_movil.persona, f: f %>      
         <%= render 'terminales', terminal_moviles: @lin_movil.terminal_movil.where('nCodEstado in (2,4,6,9)').order('dFchUltimaAsignacion desc'), f: f %>      
+        <%= render 'tarjetas', tarjetas: @lin_movil.tarjeta_movil.order('dFechaEntrega desc'), f: f %>      
       </ul>
       </div>
     </div>

--- a/app/views/lin_moviles/_tarjetas.html.erb
+++ b/app/views/lin_moviles/_tarjetas.html.erb
@@ -1,0 +1,32 @@
+<li class="accordion-item  is-active" data-accordion-item>
+    <a href="#" class="accordion-title">Tarjetas SIM</a>
+        <div class="accordion-content" data-tab-content >                                  
+                       
+            <div class="table-scroll">
+                <table>
+                    <thead class="color-cabecera">
+                            <tr>            
+                                <th><%= t('tarjeta_movil.cICC') %></th>
+                                <th><%= t('tarjeta_movil.dFechaEntrega') %></th>
+                                <th><%= t('tarjeta_movil.dFechaDevolu') %></th>
+                                <th><%= t('tarjeta_movil.bDual') %></th>
+                                <th><%= t('tarjeta_movil.bActiva') %></th>
+                                <th><%= t('tarjeta_movil.cCodClase') %></th>
+                            </tr>
+                        </thead>                                
+                        <tbody>          
+                            <% tarjetas.each do |t| %>
+                                <tr>       
+                                    <td><%= t.cICC %></td>
+                                    <td><%= t.dFechaEntrega.strftime("%d-%m-%Y") rescue nil %></td>
+                                    <td><%= t.dFechaDevolu.strftime("%d-%m-%Y") rescue nil %></td>
+                                    <td><%= t.bDual %></td>
+                                    <td><%= t.bActiva %></td>
+                                    <td><%= t.cCodClase %></td>
+                                </tr>                    
+                            <% end %>                
+                        </tbody>
+                    </table>
+                </div>         
+        </div>
+</li>

--- a/app/views/lin_moviles/_terminales.html.erb
+++ b/app/views/lin_moviles/_terminales.html.erb
@@ -1,5 +1,5 @@
 <li class="accordion-item  is-active" data-accordion-item>
-    <a href="#" class="accordion-title">Terminal</a>
+    <a href="#" class="accordion-title">Terminales</a>
         <div class="accordion-content" data-tab-content >                                  
                        
             <div class="table-scroll">

--- a/config/locales/activerecord.es.yml
+++ b/config/locales/activerecord.es.yml
@@ -60,6 +60,15 @@ es:
         one: "Modelo"
         other: "Modelos"
 
+      tarjeta_movil:
+        one: "Tarjeta SIM"
+        other: "Tarjetas SIM"
+
+      terminal_movil:
+        one: "Terminal"
+        other: "Terminal Móviles"
+
+
     attributes:
       usuario:
         cCodUsuario: "Código"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -173,6 +173,14 @@ es:
     siteB: "Site B"
     mpr: "MPR (B)"
 
+  tarjeta_movil:
+    cICC: "ICC"
+    dFechaEntrega: "Fch.Activación"
+    dFechaDevolu: "Fch.Devolución"
+    bDual: "Dual"
+    bActiva: "Activa"
+    cCodClase: "Clase Tarjeta"
+
   terminal_movil:
     cImei: "Imei"
     cImei2: "Imei2"


### PR DESCRIPTION
Incluye un Grid con la información de las tarjetas SIM asociadas a una línea móvil. 
A nivel de model, se incluye el modelo tarjeta_movil para poder implementar esta funcionalidad.