### PR TITLE
Consumo móvil en Lin Móvil

### DIFF
--- a/app/models/consumo_movil.rb
+++ b/app/models/consumo_movil.rb
@@ -1,0 +1,8 @@
+class ConsumoMovil < ApplicationRecord
+    
+    self.table_name ="geslico.dbo.ConsumoMovil"
+
+    belongs_to :linea, :foreign_key => "nLinea", :primary_key=> "nLinea"
+    belongs_to :lin_movil, :foreign_key => "nLinea", :primary_key=> "nLinea"
+
+end

--- a/app/models/lin_movil.rb
+++ b/app/models/lin_movil.rb
@@ -13,6 +13,7 @@ class LinMovil < ApplicationRecord
     has_one :sede, :foreign_key => "nCodSede", :primary_key => "nCodSede"
     has_many :terminal_movil, :foreign_key => "nLinea", :primary_key => "nLinea"    
     has_many :tarjeta_movil, :foreign_key => "nLineaMovil", :primary_key => "nLinea"    
+    has_many :consumo_movil, :foreign_key => "nLinea", :primary_key => "nLinea"    
 
     ransack_alias :lin_movil, :linea_cNumero_or_linea_cNumCorto_or_cObserva_or_cPerfil_or_cPerfilAutorizado_or_cCoberturaNormativa_or_cDNI_or_persona_cnombre_or_persona_cape1_or_persona_cape2_or_linea_unidad_cDenominacion_or_tipo_lin_movil_cDescTipoMovil_or_sede_cNombre
     

--- a/app/models/linea.rb
+++ b/app/models/linea.rb
@@ -14,6 +14,8 @@ class Linea < ApplicationRecord
 	has_many :lin_fijos_puestos, :foreign_key => "nLineaFija", :primary_key=> "nLinea"
 	has_one :lin_dato, :foreign_key => "nLinea"
 	
+	has_many :consumo_movil, :foreign_key => "nLinea", :primary_key => "nLinea"
+
 	accepts_nested_attributes_for :lin_movil
 
 	validates :cNumero, :uniqueness => true, :numericality => true, :length => { :minimum => 9, :maximum => 15 }, unless: :cNumCorto?

--- a/app/views/lin_moviles/_consumos.html.erb
+++ b/app/views/lin_moviles/_consumos.html.erb
@@ -1,0 +1,40 @@
+<% if can? :cru, ConsumoMovil %>
+    <li class="accordion-item  is-active" data-accordion-item>
+        <a href="#" class="accordion-title"><%= t('activerecord.models.consumo_movil.one') %></a>
+            <div class="accordion-content" data-tab-content >                                  
+                        
+                <div class="table-scroll">
+                    <table>
+                        <thead class="color-cabecera">
+                                <tr>            
+                                    <th><%= t('consumo_movil.nAnno') %></th>
+                                    <th><%= t('consumo_movil.cMes') %></th>
+                                    <th class="text-right"><%= t('consumo_movil.nNumLlamadas') %></th>
+                                    <th class="text-right"><%= t('consumo_movil.nSMS') %></th>
+                                    <th class="text-right"><%= t('consumo_movil.nMegabytes') %></th>
+                                    <th class="text-right"><%= t('consumo_movil.Cuota') %></th>
+                                    <th class="text-right"><%= t('consumo_movil.Voz') %></th>
+                                    <th class="text-right"><%= t('consumo_movil.Datos') %></th>
+                                    <th class="text-right"><%= t('consumo_movil.Total') %></th>
+                                </tr>
+                            </thead>                                
+                            <tbody>          
+                                <% consumos.each do |c| %>
+                                    <tr>       
+                                        <td><%= c.nAnno %></td>
+                                        <td><%= c.cMes %></td>
+                                        <td class="text-right"><%= c.nNumLlamadas rescue nil %></td>
+                                        <td class="text-right"><%= c.nSMS rescue nil %></td>
+                                        <td class="text-right"><%= number_to_human(c.nMegabytes, units: {unit: "Mb", thousand: "Gb"}, :format => "%n %u  ", separator: ",", delimiter: ".") rescue nil %></td>
+                                        <td class="text-right"><%= number_to_currency(c.Cuota, :unit => "€", :format => "%n %u  ", separator: ",", delimiter: ".") rescue nil %></td>
+                                        <td class="text-right"><%= number_to_currency(c.Voz, :unit => "€", :format => "%n %u  ", separator: ",", delimiter: ".") rescue nil %></td>
+                                        <td class="text-right"><%= number_to_currency(c.Datos, :unit => "€", :format => "%n %u  ", separator: ",", delimiter: ".") rescue nil %></td>
+                                        <td class="text-right"><%= number_to_currency(c.Total, :unit => "€", :format => "%n %u  ", separator: ",", delimiter: ".")  rescue nil %></td>
+                                    </tr>                    
+                                <% end %>                
+                            </tbody>
+                        </table>
+                    </div>         
+            </div>
+    </li>
+<% end %>

--- a/app/views/lin_moviles/_form.html.erb
+++ b/app/views/lin_moviles/_form.html.erb
@@ -87,7 +87,10 @@
         <%= render 'linea', f: f %>      
         <%= render 'persona', persona: @lin_movil.persona, f: f %>      
         <%= render 'terminales', terminal_moviles: @lin_movil.terminal_movil.where('nCodEstado in (2,4,6,9)').order('dFchUltimaAsignacion desc'), f: f %>      
-        <%= render 'tarjetas', tarjetas: @lin_movil.tarjeta_movil.order('dFechaEntrega desc'), f: f %>      
+        <%= render 'tarjetas', tarjetas: @lin_movil.tarjeta_movil.order('dFechaEntrega desc'), f: f %>
+        <% if can? :cru, ConsumoMovil %>
+          <%= render 'consumos', consumos: @lin_movil.consumo_movil.where('dFechaFactura >= dateadd(m,-13, getdate())').order('dFechaFactura desc'), f: f %>
+        <% end %>
       </ul>
       </div>
     </div>

--- a/config/locales/activerecord.es.yml
+++ b/config/locales/activerecord.es.yml
@@ -35,6 +35,10 @@ es:
         other: "Acrónimos"
         new:  "Nuevo Acrónimo" 
 
+      consumo_movil:
+        one: "Consumo móvil"
+        other: "Consumos móviles"
+
       linea:
         one: "Línea"
         other: "Líneas"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -46,6 +46,17 @@ es:
     manage:
       all: "Acceso no autorizado. Debe iniciar sesión."
 
+  consumo_movil:
+    nAnno: "Año"
+    cMes: "Mes"
+    nNumLlamadas: "Llamadas"
+    nSMS: "SMS"
+    nMegabytes: "Volumen"
+    Cuota: "Cuota"
+    Voz: "Voz"
+    Datos: "Datos"
+    Total: "Total"
+
   estado_terminales_movil:
     cEstado: "Estado"
 


### PR DESCRIPTION
Incluye el modelo y vista para mostrar el grid de los consumos de móvil.
Se ha creado una vista en la base de datos, ConsumoMovil, para simplificar el trabajo. En la aplicación original no funcionaba así.